### PR TITLE
Different HTTP response header when token is expired

### DIFF
--- a/src/TreeHouse/KeystoneBundle/Exception/TokenExpiredException.php
+++ b/src/TreeHouse/KeystoneBundle/Exception/TokenExpiredException.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace TreeHouse\KeystoneBundle\Exception;
+
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+class TokenExpiredException extends AuthenticationException
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getMessageKey()
+    {
+        return 'Token expired.';
+    }
+}

--- a/src/TreeHouse/KeystoneBundle/Manager/TokenManager.php
+++ b/src/TreeHouse/KeystoneBundle/Manager/TokenManager.php
@@ -99,9 +99,21 @@ class TokenManager
     /**
      * @param Token $token
      *
+     * @deprecated use $this->isExpired instead
+     *
      * @return boolean
      */
     public function validate(Token $token)
+    {
+        return $this->isExpired($token);
+    }
+
+    /**
+     * @param Token $token
+     *
+     * @return bool
+     */
+    public function isExpired(Token $token)
     {
         return new \DateTime() < $token->getExpiresAt();
     }

--- a/src/TreeHouse/KeystoneBundle/Tests/Controller/TokenControllerTest.php
+++ b/src/TreeHouse/KeystoneBundle/Tests/Controller/TokenControllerTest.php
@@ -135,8 +135,27 @@ class TokenControllerTest extends WebTestCase
         );
         $response = $this->client->getResponse();
 
-        $this->assertEquals(419, $response->getStatusCode());
+        $this->assertEquals(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
         $this->assertEquals(['error' => 'Token expired'], json_decode($response->getContent(), true));
+    }
+
+    public function testInvalidTokenRequest()
+    {
+        $tokenId = 'invalid-token';
+
+        $this->client->request(
+            'GET',
+            $this->getRoute('test_api'),
+            [],
+            [],
+            ['HTTP_X-Auth-Token' => $tokenId],
+            null,
+            true
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertEquals(Response::HTTP_BAD_REQUEST, $response->getStatusCode());
+        $this->assertEquals(['error' => 'Authentication Failed'], json_decode($response->getContent(), true));
     }
 
     /**

--- a/src/TreeHouse/KeystoneBundle/Tests/Controller/TokenControllerTest.php
+++ b/src/TreeHouse/KeystoneBundle/Tests/Controller/TokenControllerTest.php
@@ -99,18 +99,44 @@ class TokenControllerTest extends WebTestCase
     public function testNonAuthenticatedRequest()
     {
         $this->client->request('GET', $this->getRoute('test_api'));
-        $repsonse = $this->client->getResponse();
+        $response = $this->client->getResponse();
 
-        $this->assertEquals(Response::HTTP_FORBIDDEN, $repsonse->getStatusCode());
+        $this->assertEquals(Response::HTTP_FORBIDDEN, $response->getStatusCode());
     }
 
     public function testAuthenticatedRequest()
     {
         $this->requestWithValidToken('GET', $this->getRoute('test_api'));
-        $repsonse = $this->client->getResponse();
+        $response = $this->client->getResponse();
 
-        $this->assertEquals(Response::HTTP_OK, $repsonse->getStatusCode());
-        $this->assertEquals(['ok' => 'it works!'], json_decode($repsonse->getContent(), true));
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertEquals(['ok' => 'it works!'], json_decode($response->getContent(), true));
+    }
+
+    public function testAuthenticatedExpiredTokenRequest()
+    {
+        $tokenId = $this->requestToken()['access']['token']['id'];
+
+        // expire token in database
+        $doctrine = static::$kernel->getContainer()->get('doctrine');
+        $token = $doctrine->getRepository('TreeHouseKeystoneBundle:Token')->find($tokenId);
+        $token->setExpiresAt(new \DateTime('-1 day'));
+        $doctrine->getManager()->flush();
+
+        // perform request with token that is now expired
+        $this->client->request(
+            'GET',
+            $this->getRoute('test_api'),
+            [],
+            [],
+            ['HTTP_X-Auth-Token' => $tokenId],
+            null,
+            true
+        );
+        $response = $this->client->getResponse();
+
+        $this->assertEquals(419, $response->getStatusCode());
+        $this->assertEquals(['error' => 'Token expired'], json_decode($response->getContent(), true));
     }
 
     /**


### PR DESCRIPTION
So we can more easily see what kind of authentication issues we have.
Especially when we stack multiple authentication layers. (for example
api authentication + user authentication)