### PR TITLE
Travis improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,41 @@
 sudo: false
 
+language: php
+
 cache:
   directories:
-    - $COMPOSER_CACHE_DIR
-
-language: php
+    - $HOME/.composer/cache
 
 php:
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 matrix:
   fast_finish: true
+  include:
+    - php: 5.6
+      env: SYMFONY_VERSION=2.6.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: SYMFONY_VERSION=2.8.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.0.*
   allow_failures:
     - php: hhvm
+    - env: SYMFONY_VERSION=3.0.*
+
+before_install:
+  - composer self-update
+  - if [ "$SYMFONY_VERSION" != "" ]; then composer require "symfony/symfony:${SYMFONY_VERSION}" --no-update; fi;
 
 install:
-  - composer self-update
-
-before_script:
-  - composer install --no-interaction --prefer-source --dev
+  - composer update --prefer-dist --no-interaction
 
 script:
-  - ./vendor/bin/phpunit --coverage-clover=coverage.clover
+  - ./vendor/bin/phpunit --coverage-text --coverage-clover=coverage.clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar


### PR DESCRIPTION
* Performance improvement by using correct cache directory
* Added PHP7 to the build matrix
* Added current supported Symfony versions to the build matrix, we test this only on the most used php version (5.6)

Symfony 3.0 is currently allowed to fail and is failing. We still have to fix this. But we can easily see it now.

This might be a nice boilerplate we can use for our other bundles. I took some inspiration from the FosUserBundle.