### PR TITLE
Fixed TokenManager::isExpired()

### DIFF
--- a/src/TreeHouse/KeystoneBundle/Manager/TokenManager.php
+++ b/src/TreeHouse/KeystoneBundle/Manager/TokenManager.php
@@ -101,7 +101,7 @@ class TokenManager
      */
     public function isExpired(Token $token)
     {
-        return new \DateTime() < $token->getExpiresAt();
+        return new \DateTime() > $token->getExpiresAt();
     }
 
     /**

--- a/src/TreeHouse/KeystoneBundle/Model/Token.php
+++ b/src/TreeHouse/KeystoneBundle/Model/Token.php
@@ -30,7 +30,7 @@ class Token
     /**
      * @param string $hash
      *
-     * @return Token
+     * @return $this
      */
     public function setHash($hash)
     {
@@ -50,7 +50,7 @@ class Token
     /**
      * @param \DateTime $expiresAt
      *
-     * @return Token
+     * @return $this
      */
     public function setExpiresAt($expiresAt)
     {

--- a/src/TreeHouse/KeystoneBundle/Security/Authentication/AbstractTokenAuthenticator.php
+++ b/src/TreeHouse/KeystoneBundle/Security/Authentication/AbstractTokenAuthenticator.php
@@ -79,7 +79,7 @@ abstract class AbstractTokenAuthenticator implements AuthenticationFailureHandle
             throw new BadCredentialsException('Bad token');
         }
 
-        if (false === $this->tokenManager->isExpired($tokenEntity)) {
+        if (true === $this->tokenManager->isExpired($tokenEntity)) {
             throw new TokenExpiredException('Token expired');
         }
 

--- a/tests/TreeHouse/KeystoneBundle/Tests/Manager/TokenManagerTest.php
+++ b/tests/TreeHouse/KeystoneBundle/Tests/Manager/TokenManagerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace TreeHouse\KeystoneBundle\Tests\Manager;
+
+use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\EntityManagerInterface;
+use TreeHouse\KeystoneBundle\Entity\Token;
+use TreeHouse\KeystoneBundle\Manager\TokenManager;
+use TreeHouse\KeystoneBundle\Security\Encoder\TokenEncoder;
+use TreeHouse\KeystoneIntegrationBundle\Entity\User;
+
+class TokenManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var string
+     */
+    private $secret = 'sup3rs3cr4t';
+
+    /**
+     * @var \PHPUnit_Framework_MockObject_MockObject|ManagerRegistry
+     */
+    private $doctrine;
+
+    /**
+     * @var TokenManager
+     */
+    private $manager;
+
+    protected function setUp()
+    {
+        $encoder = new TokenEncoder($this->secret);
+        $this->doctrine = $this->createDoctrineMock();
+        $this->doctrine
+            ->expects($this->any())
+            ->method('getManager')
+            ->willReturn($this->getMockForAbstractClass(EntityManagerInterface::class))
+        ;
+
+        $this->manager = new TokenManager($encoder, $this->doctrine);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_create_a_token()
+    {
+        $user = new User();
+        $ttl = 600;
+
+        $token = $this->manager->createToken($user, $ttl);
+
+        $this->assertInstanceOf(Token::class, $token);
+        $this->assertNotEmpty($token->getHash());
+        $this->assertEquals($ttl, $token->getExpiresAt()->getTimestamp() - time(), 'Token should be created with TTL', 2);
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_check_for_expired_tokens()
+    {
+        $this->assertFalse($this->manager->isExpired((new Token())->setExpiresAt(new \DateTime('10 seconds'))));
+        $this->assertTrue($this->manager->isExpired((new Token())->setExpiresAt(new \DateTime('-10 seconds'))));
+    }
+
+    /**
+     * @return \PHPUnit_Framework_MockObject_MockObject|ManagerREgistry
+     */
+    private function createDoctrineMock()
+    {
+        return $this
+            ->getMockBuilder(ManagerRegistry::class)
+            ->getMockForAbstractClass()
+        ;
+    }
+}


### PR DESCRIPTION
Epic screw up where both the `isExpired` and the place where it was checked were checking the wrong thing, thereby actually making it work again.
